### PR TITLE
Bugfix#58307

### DIFF
--- a/Branch.readme
+++ b/Branch.readme
@@ -1,0 +1,5 @@
+Branch name: calcsymb
+
+Description: This is a branch where the work for eliminating the difference between
+CalcSymbol and StackType will be done.  There is no fundamental reason now to distinguish
+between objects in the symbol table (CalcSymbol) and objects on the stacks (StackType).

--- a/doc/GNUFussyHomepage/fussy.texinfo
+++ b/doc/GNUFussyHomepage/fussy.texinfo
@@ -495,7 +495,7 @@ The fussy language defines the following special operators:
                @ref{Sub-expressions}). Expressions like
                @t{sin(x:=0.1pm0.02)} are equivalent to
                @t{x:=0.1pm0.02;sin(x);}.
-@cindex Partial assignent operator
+@cindex Partial assignment operator
 
 @item         '@t{pm}': For associating an error with numerical values.
 	      E.g. 10 +/- 1.0 is expressed as 10pm1.
@@ -821,7 +821,7 @@ Following are some commands useful in an interactive session:
 
 @itemize
 @item @t{quit/bye}: The only two ways to quit from the interpreter.
-              Politer (more civlized) of the two commands is more 
+              Politer (more civilized) of the two commands is more 
               recommended!
               Typing @t{Ctrl-D} will exit the interpreter
               after number of trials given by the environment variable

--- a/doc/GNUFussyHomepage/fussy.texinfo
+++ b/doc/GNUFussyHomepage/fussy.texinfo
@@ -240,6 +240,9 @@ configuration file
 @item @t{FUSSY_IGNOREEOF}: An integer value indicating the number of
 times a @t{Ctrl-D} input to the interpreter will be ignored before
 quitting.  Default values is @math{10^6}.
+@item @t{FUSSY_PROMPT}: A string value used as the prompt in
+interactive session.  If not set, a default value of @t{'>'} is
+used. Set it to @t{""} for no prompt.
 @end enumerate
 
 @node Examples

--- a/src/fussy.cc
+++ b/src/fussy.cc
@@ -55,6 +55,7 @@
 #include "namespace.h"
 #include "config.h"
 #include <sstream>
+#include <readline/history.h>
 
 extern int   calc_debug;
 extern FILE  *rl_instream;
@@ -125,6 +126,14 @@ void LoadFile(const char *Name)
     }
   else	
     ReportErr(strerror(errno),"###Informational",ErrorObj::Informational);
+}
+//
+//---------------------------------------------------------------------
+//
+void allDone(const bool bePolite=true,const int exitStatus=0)
+{
+  if (bePolite)  {ErrorObj tt; tt << "Goodbye!" << endl;}
+  exit(exitStatus);
 }
 //
 //---------------------------------------------------------------------
@@ -263,8 +272,8 @@ int main(int argc, char *argv[])
     catch (ErrorObj& e)        {e << e.what() << endl;}
     catch (BreakException& x)  {}
     catch (ReturnException& x) {}
-    catch (ExitException& x)   {ErrorObj tt; tt << "Goodbye!" << endl;exit(0);}
+    catch (ExitException& x)   {allDone(!beQuiet);}
     catch (...) {MsgStream << "Caught an unknown exception" << endl;}
-  if (VMState_Quit)  {ErrorObj tt; tt << "Goodbye!" << endl;exit(0);}
+  if (VMState_Quit)  {allDone(!beQuiet);}
 }
 

--- a/src/fussylex.l
+++ b/src/fussylex.l
@@ -291,6 +291,8 @@ void HandleExtendedNum(const char *Units, const double &ToRadians)
 //
 //-----------------------------------------------------------------
 //
+// FREAL   ({NUM}([Dd]{S}{DIGIT})?)
+// RNUM    ({CREAL}|{FREAL})
 %}
 DIGIT   [0-9]+
 HEXD    0x[0-9a-fA-F]++
@@ -323,8 +325,7 @@ ERROP   ({PM}|{PMSIGN})
 SPACE   [ ]++
 NUM     ({DIGIT}|{DIGIT}{DOT}|{DOT}{DIGIT}|{DIGIT}{DOT}{DIGIT})
 CREAL   ({NUM}([Ee]{S}{DIGIT})?)
-FREAL   ({NUM}([Dd]{S}{DIGIT})?)
-RNUM    ({CREAL}|{FREAL})
+RNUM    ({CREAL})
 
 HDEG    ({RNUM}h)
 HMIN    ({RNUM}m)

--- a/src/fussylex.l
+++ b/src/fussylex.l
@@ -103,9 +103,11 @@ void fussy_inp(char *buf, int *result, int max_size)
 {                                   
   int N;
   static size_t Count=0;
+  char *tt=NULL;
 
   if (GlobalFlag & FLAG_MORE_INP) Calc_prompt=" ";
-  else Calc_prompt=">";
+  //  else Calc_prompt=">";
+  else Calc_prompt=((tt=getenv("FUSSY_PROMPT"))==NULL?">":tt);
 
   if (Calc_line && (Count==strlen(Calc_line))) 
     {

--- a/src/test/error.test.procassgn.out
+++ b/src/test/error.test.procassgn.out
@@ -19,4 +19,3 @@
 /****************************************************************************/
 ###Error: Syntax error near token 'f' in "y=f(10.0);"
 ###Error: PROC used in an assigment ('=') statement
-Goodbye!

--- a/src/test/test.laguerre
+++ b/src/test/test.laguerre
@@ -36,14 +36,26 @@
 
 f(n,x)
 {
+  /* return ((2*n-1-x)*f(n-1,x)-(n-1)*f(n-2,x))/n; */
+  /* Code below is a version of the above expression, written using partial variables */
+  auto p0,p1,p2;
   if (n<=0) return 1;
   if (n==1) return 1-x;
-  return ((2*n-1-x)*f(n-1,x)-(n-1)*f(n-2,x))/n;
+
+  p0:=(2*n-1-x);
+  p1:=f(n-1,x);
+  p2:=(n-1)*f(n-2,x);
+  return (p0*p1-p2)/n;
 }
 
 df(n,x)
 {
-  return (n*f(n,x)-n*f(n-1,x))/x;
+  /*  return (n*f(n,x)-n*f(n-1,x))/x;*/
+  /* Code below is a version of the above expression, written using partial variables */
+  auto n0,n1;
+  n0:=n*f(n,x);
+  n1:=n*f(n-1,x);
+  return (n0-n1)/x;
 }
 
 test(x)


### PR DESCRIPTION
Fixes bu #58307 on Savannah.

Summary: Numbers in 10d3 (instead of 10e3) format are disabled.  This interfered with expressions involving numbers in DMS format.